### PR TITLE
chore: Change demo.gif URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Visualizations done with [Three.js](https://github.com/mrdoob/three.js/).
 
 Demo available [here](http://scottyfillups.github.io/gyronorm-viz). It only works on mobile; try tilting your phone!
 
-![gyronorm-viz demo](http://scottyfillups.github.io/gyronorm-viz/assets/demo.gif)
+![gyronorm-viz demo](https://raw.githubusercontent.com/ScottyFillups/gyronorm-viz/master/assets/demo.gif)
 
 ## Licensing
 


### PR DESCRIPTION
## Context

Hosting `demo.gif` on Github Pages doesn't make sense; it's already hosted on <https://raw.githubusercontent.com>

## Objective 

* Change demo.gif URL to point to `master`