### PR TITLE
fix: Use relative path when building

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Philip Scott <pscott@zeptohost.com>",
   "license": "MIT",
   "scripts": {
-    "build": "parcel build ./src/index.html",
+    "build": "parcel build ./src/index.html --public-url '.'",
     "dev": "parcel ./src/index.html",
     "test": "echo \"No test specified!\""
   },


### PR DESCRIPTION
## Context

Parcel defaults to using absolute paths when building. Since the demo site is under the `gyronorm-viz` namespace (http://scottyfillups.io/gyronorm-viz), absolute paths will not work.

## Objective

* Use relative paths instead of absolute paths